### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=MZachmann
 maintainer=https://github.com/MZachmann/LightLora_Arduino
 sentence=Interrupt-driven Semtech SX127x-based board control. High and low-level routines.
 paragraph=The LightLora library is designed for arduino and lightweight cpus. Tested on Feather M0 LoRa and the Feather Nrf52 with external inAir9B LoRa board.
-category=Wireless Communications
+category=Communication
 url=https://github.com/MZachmann/LightLora_Arduino
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Wireless Communications' in library LightLora is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format